### PR TITLE
Store the environment at startup and restore it before reexecing

### DIFF
--- a/bin/einhorn
+++ b/bin/einhorn
@@ -167,6 +167,7 @@ end
 if true # $0 == __FILE__
   Einhorn::TransientState.script_name = $0
   Einhorn::TransientState.argv = ARGV.dup
+  Einhorn::TransientState.environ = ENV.to_hash
 
   optparse = OptionParser.new do |opts|
     opts.on('-b', '--command-socket-as-fd', 'Leave the command socket open as a file descriptor, passed in the EINHORN_FD environment variable. This allows your worker processes to ACK without needing to know where on the filesystem the command socket lives.') do

--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -68,6 +68,7 @@ module Einhorn
         :preloaded => false,
         :script_name => nil,
         :argv => [],
+        :environ => {},
         :has_outstanding_spinup_timer => false,
         :stateful => nil,
         # Holds references so that the GC doesn't go and close your sockets.

--- a/lib/einhorn/command.rb
+++ b/lib/einhorn/command.rb
@@ -172,6 +172,10 @@ module Einhorn
 
       Einhorn::Event.uninit
 
+      # Reload the original environment
+      ENV.clear
+      ENV.update(Einhorn::TransientState.environ)
+
       exec [Einhorn::TransientState.script_name, Einhorn::TransientState.script_name], *(['--with-state-fd', read.fileno.to_s, '--'] + Einhorn::State.cmd)
     end
 


### PR DESCRIPTION
This makes sure that pre-loaded code isn't able to change the
environment in ways that impact subsequent restarts of einhorn (for
instance by repointing bundler to look at a different Gemfile).

Fixes einhorn issue #7

reviewer: @gdb

I'd love to add tests for this, but I'm not really sure how to set it all up, given the number of moving parts involved. To test by hand, the following script will throw during preloading when run without my patch:

``` ruby
require 'einhorn/client'

raise "Environment changes were preserved" if ENV.include?("SPECIAL_EINHORN_TEST_ENV")
# This should go away the next time einhorn is reloaded
ENV["SPECIAL_EINHORN_TEST_ENV"] = "hello"

def einhorn_main
  # Sit around doing nothing, then trigger an upgrade
  IO.select([], [], [], 1)

  client = Einhorn::Client.for_path(ENV['EINHORN_SOCK_PATH'])
  client.command({'command' => 'upgrade'})
end
```
