### PR TITLE
Switch from EINHORN_FDS to EINHORN_FD_N/EINHORN_FD_COUNT

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,17 @@ Each address is specified as an ip/port pair, possibly accompanied by options:
     ADDR := (IP:PORT)[<,OPT>...]
 
 In the worker process, the opened file descriptors will be represented
-as a space-separated list of file descriptor numbers in the
-EINHORN_FDS environment variable (respecting the order that the `-b`
-options were provided in):
+as file descriptor numbers in a series of environment variables named
+EINHORN_FD_1, EINHORN_FD_2, etc. (respecting the order that the `-b`
+options were provided in), with the total number of file descriptors
+in the EINHORN_FD_COUNT environment variable:
 
-    EINHORN_FDS="6" # 127.0.0.1:1234
-    EINHORN_FDS="6 7" # 127.0.0.1:1234,r 127.0.0.1:1235
+    EINHORN_FD_1="6" # 127.0.0.1:1234
+    EINHORN_FD_COUNT="1"
+
+    EINHORN_FD_1="6" # 127.0.0.1:1234,r
+    EINHORN_FD_2="7" # 127.0.0.1:1235
+    EINHORN_FD_COUNT="2"
 
 Valid opts are:
 
@@ -98,7 +103,7 @@ You can for example run:
 
 Which will run 4 copies of
 
-    EINHORN_FDS=6 example/time_server
+    EINHORN_FD_1=6 EINHORN_FD_COUNT=1 example/time_server
 
 Where file descriptor 6 is a server socket bound to `127.0.0.1:2345`
 and with `SO_REUSEADDR` set. It is then your application's job to
@@ -191,7 +196,7 @@ pass `-c <name>`.
 
 ### Options
 
-    -b, --bind ADDR                  Bind an address and add the corresponding FD to EINHORN_FDS
+    -b, --bind ADDR                  Bind an address and add the corresponding FD via the environment
     -c, --command-name CMD_NAME      Set the command name in ps to this value
     -d, --socket-path PATH           Where to open the Einhorn command socket
     -e, --pidfile PIDFILE            Where to write out the Einhorn pidfile

--- a/bin/einhorn
+++ b/bin/einhorn
@@ -56,12 +56,17 @@ Each address is specified as an ip/port pair, possibly accompanied by options:
     ADDR := (IP:PORT)[<,OPT>...]
 
 In the worker process, the opened file descriptors will be represented
-as a space-separated list of file descriptor numbers in the
-EINHORN_FDS environment variable (respecting the order that the `-b`
-options were provided in):
+as file descriptor numbers in a series of environment variables named
+EINHORN_FD_1, EINHORN_FD_2, etc. (respecting the order that the `-b`
+options were provided in), with the total number of file descriptors
+in the EINHORN_FD_COUNT environment variable:
 
-    EINHORN_FDS="6" # 127.0.0.1:1234
-    EINHORN_FDS="6 7" # 127.0.0.1:1234,r 127.0.0.1:1235
+    EINHORN_FD_1="6" # 127.0.0.1:1234
+    EINHORN_FD_COUNT="1"
+
+    EINHORN_FD_1="6" # 127.0.0.1:1234,r
+    EINHORN_FD_2="7" # 127.0.0.1:1235
+    EINHORN_FD_COUNT="2"
 
 Valid opts are:
 
@@ -74,7 +79,7 @@ You can for example run:
 
 Which will run 4 copies of
 
-    EINHORN_FDS=6 example/time_server
+    EINHORN_FD_1=6 EINHORN_FD_COUNT=1 example/time_server
 
 Where file descriptor 6 is a server socket bound to `127.0.0.1:2345`
 and with `SO_REUSEADDR` set. It is then your application's job to
@@ -184,7 +189,7 @@ if true # $0 == __FILE__
   Einhorn::TransientState.environ = ENV.to_hash
 
   optparse = OptionParser.new do |opts|
-    opts.on('-b ADDR', '--bind ADDR', 'Bind an address and add the corresponding FD to EINHORN_FDS') do |addr|
+    opts.on('-b ADDR', '--bind ADDR', 'Bind an address and add the corresponding FD via the environment') do |addr|
       unless addr =~ /\A([^:]+):(\d+)((?:,\w+)*)\Z/
         raise "Invalid value for #{addr.inspect}: bind address must be of the form address:port[,flags...]"
       end

--- a/example/thin_example
+++ b/example/thin_example
@@ -27,10 +27,9 @@ end
 
 def einhorn_main
   puts "Called with #{ARGV.inspect}"
+  fd_count = Einhorn::Worker.einhorn_fd_count
 
-  einhorn_fds = Einhorn::Worker.einhorn_fds
-
-  unless einhorn_fds
+  unless fd_count > 0
     raise "Need to call with at least one bound socket. Try running 'einhorn -b 127.0.0.1:5000,r,n -b 127.0.0.1:5001,r,n #{$0}' and then running 'curl 127.0.0.1:5000' or 'curl 127.0.0.1:5001'"
   end
 
@@ -41,7 +40,8 @@ def einhorn_main
   Einhorn::Worker.ack!
 
   EventMachine.run do
-    einhorn_fds.each_with_index do |sock, i|
+    (0...fd_count).each do |i|
+      sock = Einhorn::Worker.socket!(i)
       srv = Thin::Server.new(sock, App.new(i), :reuse => true)
       srv.start
     end

--- a/example/time_server
+++ b/example/time_server
@@ -2,7 +2,8 @@
 #
 # A simple example showing how to use Einhorn's shared-socket
 # features. Einhorn translates the (addr:port[,flags...]) bind spec in
-# into a file descriptor number in the EINHORN_FDS environment variable.
+# into a file descriptor number in the EINHORN_FD_# environment
+# variables.
 #
 # Invoke through Einhorn as
 #
@@ -15,7 +16,7 @@ require 'rubygems'
 require 'einhorn/worker'
 
 def einhorn_main
-  puts "Called with ENV['EINHORN_FDS']: #{ENV['EINHORN_FDS']}"
+  puts "Called with ENV['EINHORN_FD_1']: #{ENV['EINHORN_FD_1']}"
 
   fd_num = Einhorn::Worker.socket!
   socket = Socket.for_fd(fd_num)

--- a/lib/einhorn/command.rb
+++ b/lib/einhorn/command.rb
@@ -266,9 +266,14 @@ module Einhorn
         Einhorn::TransientState.socket_handles << socket
         ENV['EINHORN_SOCK_FD'] = socket.fileno.to_s
       end
-      # Try to match Upstart's internal support for space-separated FD
-      # lists. (I don't think anyone actually uses that functionality,
-      # but seems reasonable enough.)
+
+      ENV['EINHORN_FD_COUNT'] = Einhorn::State.bind_fds.length.to_s
+      Einhorn::State.bind_fds.each_with_index {|fd, i| ENV["EINHORN_FD_#{i}"] = fd.to_s}
+
+      # EINHORN_FDS is deprecated. It was originally an attempt to
+      # match Upstart's nominal internal support for space-separated
+      # FD lists, but nobody uses that in practice, and it makes
+      # finding individual FDs more difficult
       ENV['EINHORN_FDS'] = Einhorn::State.bind_fds.map(&:to_s).join(' ')
     end
 

--- a/lib/einhorn/worker.rb
+++ b/lib/einhorn/worker.rb
@@ -80,30 +80,39 @@ module Einhorn
 
     def self.socket(number=nil)
       number ||= 0
-      fds = einhorn_fds
-      fds ? fds[number] : nil
+      einhorn_fd(number)
     end
 
     def self.socket!(number=nil)
       number ||= 0
 
-      unless fds = einhorn_fds
-        raise "No EINHORN_FDS provided in environment. Are you running under Einhorn?"
+      unless count = einhorn_fd_count
+        raise "No EINHORN_FD_COUNT provided in environment. Are you running under Einhorn?"
       end
 
-      unless number < fds.length
-        raise "Only #{fds.length} FDs available, but FD #{number} was requested"
+      unless number < count
+        raise "Only #{count} FDs available, but FD #{number} was requested"
       end
 
-      fds[number]
+      unless fd = einhorn_fd(number)
+        raise "No EINHORN_FD_#{number} provided in environment. That's pretty weird"
+      end
+
+      fd
     end
 
-    def self.einhorn_fds
-      unless raw_fds = ENV['EINHORN_FDS']
+    def self.einhorn_fd(n)
+      unless raw_fd = ENV["EINHORN_FD_#{n}"]
         return nil
       end
+      Integer(raw_fd)
+    end
 
-      raw_fds.split(' ').map {|fd| Integer(fd)}
+    def self.einhorn_fd_count
+      unless raw_count = ENV['EINHORN_FD_COUNT']
+        return 0
+      end
+      Integer(raw_count)
     end
 
     # Call this to handle graceful shutdown requests to your app.


### PR DESCRIPTION
The space-separated EINHORN_FDS interface was an attempt to pretend to
be compatible with Upstart. Upstart internally supports passing
multiple FDs, but exposes no interfaces that would allow
it. Meanwhile, having the space-separated list of FDs makes some other
applications more difficult.

@gdb: Mind taking a look?
