### PR TITLE
Fix the docs to match actual behavior of EINHORN_FD_N vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,15 +81,15 @@ Each address is specified as an ip/port pair, possibly accompanied by options:
 
 In the worker process, the opened file descriptors will be represented
 as file descriptor numbers in a series of environment variables named
-EINHORN_FD_1, EINHORN_FD_2, etc. (respecting the order that the `-b`
+EINHORN_FD_0, EINHORN_FD_1, etc. (respecting the order that the `-b`
 options were provided in), with the total number of file descriptors
 in the EINHORN_FD_COUNT environment variable:
 
-    EINHORN_FD_1="6" # 127.0.0.1:1234
+    EINHORN_FD_0="6" # 127.0.0.1:1234
     EINHORN_FD_COUNT="1"
 
-    EINHORN_FD_1="6" # 127.0.0.1:1234,r
-    EINHORN_FD_2="7" # 127.0.0.1:1235
+    EINHORN_FD_0="6" # 127.0.0.1:1234,r
+    EINHORN_FD_1="7" # 127.0.0.1:1235
     EINHORN_FD_COUNT="2"
 
 Valid opts are:
@@ -103,7 +103,7 @@ You can for example run:
 
 Which will run 4 copies of
 
-    EINHORN_FD_1=6 EINHORN_FD_COUNT=1 example/time_server
+    EINHORN_FD_0=6 EINHORN_FD_COUNT=1 example/time_server
 
 Where file descriptor 6 is a server socket bound to `127.0.0.1:2345`
 and with `SO_REUSEADDR` set. It is then your application's job to

--- a/bin/einhorn
+++ b/bin/einhorn
@@ -57,15 +57,15 @@ Each address is specified as an ip/port pair, possibly accompanied by options:
 
 In the worker process, the opened file descriptors will be represented
 as file descriptor numbers in a series of environment variables named
-EINHORN_FD_1, EINHORN_FD_2, etc. (respecting the order that the `-b`
+EINHORN_FD_0, EINHORN_FD_1, etc. (respecting the order that the `-b`
 options were provided in), with the total number of file descriptors
 in the EINHORN_FD_COUNT environment variable:
 
-    EINHORN_FD_1="6" # 127.0.0.1:1234
+    EINHORN_FD_0="6" # 127.0.0.1:1234
     EINHORN_FD_COUNT="1"
 
-    EINHORN_FD_1="6" # 127.0.0.1:1234,r
-    EINHORN_FD_2="7" # 127.0.0.1:1235
+    EINHORN_FD_0="6" # 127.0.0.1:1234,r
+    EINHORN_FD_1="7" # 127.0.0.1:1235
     EINHORN_FD_COUNT="2"
 
 Valid opts are:
@@ -79,7 +79,7 @@ You can for example run:
 
 Which will run 4 copies of
 
-    EINHORN_FD_1=6 EINHORN_FD_COUNT=1 example/time_server
+    EINHORN_FD_0=6 EINHORN_FD_COUNT=1 example/time_server
 
 Where file descriptor 6 is a server socket bound to `127.0.0.1:2345`
 and with `SO_REUSEADDR` set. It is then your application's job to

--- a/example/time_server
+++ b/example/time_server
@@ -16,7 +16,7 @@ require 'rubygems'
 require 'einhorn/worker'
 
 def einhorn_main
-  puts "Called with ENV['EINHORN_FD_1']: #{ENV['EINHORN_FD_1']}"
+  puts "Called with ENV['EINHORN_FD_0']: #{ENV['EINHORN_FD_0']}"
 
   fd_num = Einhorn::Worker.socket!
   socket = Socket.for_fd(fd_num)


### PR DESCRIPTION
They actually count from 0, not 1. I hadn't originally intended for
this to be the behavior, but now that the code is written, it seems
preferable to attempting to do a bunch of conversions between
0-indexing and 1-indexing, so I think I'd prefer to keep it.

@gdb Will merge if you don't have a strong preference for whether these should be 1-indexed or 0-indexed, but I think at this point better to keep code and fix docs than vice versa.
