### PR TITLE
Immediately stop if possible when asked

### DIFF
--- a/lib/einhorn/command.rb
+++ b/lib/einhorn/command.rb
@@ -334,6 +334,11 @@ module Einhorn
       end
     end
 
+    def self.stop_respawning
+      Einhorn::State.respawn = false
+      Einhorn::Event.break_loop
+    end
+
     def self.replenish
       return unless Einhorn::State.respawn
 

--- a/lib/einhorn/command/interface.rb
+++ b/lib/einhorn/command/interface.rb
@@ -149,17 +149,17 @@ module Einhorn::Command
     def self.install_handlers
       Signal.trap("INT") do
         Einhorn::Command.signal_all("USR2", Einhorn::WorkerPool.workers)
-        Einhorn::State.respawn = false
+        Einhorn::Command.stop_respawning
       end
       Signal.trap("TERM") do
         Einhorn::Command.signal_all("TERM", Einhorn::WorkerPool.workers)
-        Einhorn::State.respawn = false
+        Einhorn::Command.stop_respawning
       end
       # Note that quit is a bit different, in that it will actually
       # make Einhorn quit without waiting for children to exit.
       Signal.trap("QUIT") do
         Einhorn::Command.signal_all("QUIT", Einhorn::WorkerPool.workers)
-        Einhorn::State.respawn = false
+        Einhorn::Command.stop_respawning
         exit(1)
       end
       Signal.trap("HUP") {Einhorn::Command.reload}
@@ -167,12 +167,12 @@ module Einhorn::Command
       Signal.trap("CHLD") {Einhorn::Event.break_loop}
       Signal.trap("USR2") do
         Einhorn::Command.signal_all("USR2", Einhorn::WorkerPool.workers)
-        Einhorn::State.respawn = false
+        Einhorn::Command.stop_respawning
       end
       at_exit do
         if Einhorn::State.kill_children_on_exit && Einhorn::TransientState.whatami == :master
           Einhorn::Command.signal_all("USR2", Einhorn::WorkerPool.workers)
-          Einhorn::State.respawn = false
+          Einhorn::Command.stop_respawning
         end
       end
     end
@@ -353,7 +353,7 @@ EOF
       signal = args[0] || "USR2"
 
       response = Einhorn::Command.signal_all(signal, Einhorn::WorkerPool.workers)
-      Einhorn::State.respawn = false
+      Einhorn::Command.stop_respawning
 
       "Einhorn is going down! #{response}"
     end


### PR DESCRIPTION
Before this change you had to wait until the next event on the einhorn
loop. This was particularly problematic if your einhorn had gone into
exponential back-off because your process didn't start.

This was most annoying in development as you couldn't just &lt;ctrl-c> einhorn to make it stop if it was broken.
