### PR TITLE
Flip out and replace shoulda with minitest

### DIFF
--- a/einhorn.gemspec
+++ b/einhorn.gemspec
@@ -15,8 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency('rake')
-  gem.add_development_dependency('shoulda', '~> 3.4.0')
-  gem.add_development_dependency('mocha', '~> 0.3.2')
-  gem.add_development_dependency('activesupport', '~> 3.0')
+  gem.add_development_dependency('minitest', '< 5.0')
+  gem.add_development_dependency('mocha', '~> 0.13')
   gem.version       = Einhorn::VERSION
 end

--- a/test/_lib.rb
+++ b/test/_lib.rb
@@ -1,0 +1,12 @@
+require 'rubygems'
+require 'bundler/setup'
+
+require 'minitest/autorun'
+require 'minitest/spec'
+require 'mocha/setup'
+
+class EinhornTestCase < ::MiniTest::Spec
+  def setup
+    # Put global stubs here
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,0 @@
-require 'rubygems'
-require 'bundler/setup'
-
-require 'test/unit'
-require 'mocha'
-require 'shoulda'
-
-$:.unshift(File.join(File.dirname(__FILE__), '../lib'))

--- a/test/unit/einhorn.rb
+++ b/test/unit/einhorn.rb
@@ -1,14 +1,14 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require File.expand_path(File.join(File.dirname(__FILE__), '../_lib'))
 
 require 'einhorn'
 
-class EinhornTest < Test::Unit::TestCase
-  context "when sockifying" do
-    teardown do
+class EinhornTest < EinhornTestCase
+  describe "when sockifying" do
+    after do
       Einhorn::State.sockets = {}
     end
 
-    should "correctly parse srv: arguments" do
+    it "correctly parses srv: arguments" do
       cmd = ['foo', 'srv:1.2.3.4:123,llama,test', 'bar']
       Einhorn.expects(:bind).once.with('1.2.3.4', '123', ['llama', 'test']).returns(4)
 
@@ -17,7 +17,7 @@ class EinhornTest < Test::Unit::TestCase
       assert_equal(['foo', '4', 'bar'], cmd)
     end
 
-    should "correctly parse --opt=srv: arguments" do
+    it "correctly parses --opt=srv: arguments" do
       cmd = ['foo', '--opt=srv:1.2.3.4:456', 'baz']
       Einhorn.expects(:bind).once.with('1.2.3.4', '456', []).returns(5)
 
@@ -26,7 +26,7 @@ class EinhornTest < Test::Unit::TestCase
       assert_equal(['foo', '--opt=5', 'baz'], cmd)
     end
 
-    should "use the same fd number for the same server spec" do
+    it "uses the same fd number for the same server spec" do
       cmd = ['foo', '--opt=srv:1.2.3.4:8910', 'srv:1.2.3.4:8910']
       Einhorn.expects(:bind).once.with('1.2.3.4', '8910', []).returns(10)
 
@@ -36,8 +36,8 @@ class EinhornTest < Test::Unit::TestCase
     end
   end
 
-  context '.update_state' do
-    should 'correctly update keys to match new default state hash' do
+  describe '.update_state' do
+    it 'correctly updates keys to match new default state hash' do
       Einhorn::State.stubs(:default_state).returns(:baz => 23, :foo => 1)
       old_state = {:foo => 2, :bar => 2}
 
@@ -46,7 +46,7 @@ class EinhornTest < Test::Unit::TestCase
       assert_match(/State format has changed/, message)
     end
 
-    should 'not change the state if the format has not changed' do
+    it 'does not change the state if the format has not changed' do
       Einhorn::State.stubs(:default_state).returns(:baz => 23, :foo => 1)
       old_state = {:baz => 14, :foo => 1234}
 

--- a/test/unit/einhorn/client.rb
+++ b/test/unit/einhorn/client.rb
@@ -1,8 +1,8 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../../test_helper'))
+require File.expand_path(File.join(File.dirname(__FILE__), '../../_lib'))
 
 require 'einhorn'
 
-class ClientTest < Test::Unit::TestCase
+class ClientTest < EinhornTestCase
   def unserialized_message
     {:foo => ['%bar', '%baz']}
   end
@@ -15,8 +15,8 @@ class ClientTest < Test::Unit::TestCase
     "---%0A:foo:%0A- ! '%25bar'%0A- ! '%25baz'%0A\n"
   end
 
-  context "when sending a message" do
-    should "write a serialized line" do
+  describe "when sending a message" do
+    it "writes a serialized line" do
       socket = mock
       socket.expects(:write).with do |write|
         write == serialized_1_8 || write == serialized_1_9
@@ -25,15 +25,15 @@ class ClientTest < Test::Unit::TestCase
     end
   end
 
-  context "when receiving a message" do
-    should "deserialize a single 1.8-style line" do
+  describe "when receiving a message" do
+    it "deserializes a single 1.8-style line" do
       socket = mock
       socket.expects(:readline).returns(serialized_1_8)
       result = Einhorn::Client::Transport.receive_message(socket)
       assert_equal(result, unserialized_message)
     end
 
-    should "deserialize a single 1.9-style line" do
+    it "deserializes a single 1.9-style line" do
       socket = mock
       socket.expects(:readline).returns(serialized_1_9)
       result = Einhorn::Client::Transport.receive_message(socket)
@@ -41,23 +41,23 @@ class ClientTest < Test::Unit::TestCase
     end
   end
 
-  context "when {de,}serializing a message" do
-    should "serialize and escape a message as expected" do
+  describe "when {de,}serializing a message" do
+    it "serializes and escape a message as expected" do
       actual = Einhorn::Client::Transport.serialize_message(unserialized_message)
       assert(actual == serialized_1_8 || actual == serialized_1_9, "Actual message is #{actual.inspect}")
     end
 
-    should "deserialize and unescape a 1.8-style message as expected" do
+    it "deserializes and unescape a 1.8-style message as expected" do
       actual = Einhorn::Client::Transport.deserialize_message(serialized_1_8)
       assert_equal(unserialized_message, actual)
     end
 
-    should "deserialize and unescape a 1.9-style message as expected" do
+    it "deserializes and unescape a 1.9-style message as expected" do
       actual = Einhorn::Client::Transport.deserialize_message(serialized_1_9)
       assert_equal(unserialized_message, actual)
     end
 
-    should "raise an error when deserializing invalid YAML" do
+    it "raises an error when deserializing invalid YAML" do
       invalid_serialized = "-%0A\t-"
       expected = [ArgumentError]
       expected << Psych::SyntaxError if defined?(Psych::SyntaxError) # 1.9

--- a/test/unit/einhorn/command.rb
+++ b/test/unit/einhorn/command.rb
@@ -1,18 +1,18 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../../test_helper'))
+require File.expand_path(File.join(File.dirname(__FILE__), '../../_lib'))
 
 require 'einhorn'
 
-class CommandTest < Test::Unit::TestCase
+class CommandTest < EinhornTestCase
   include Einhorn
 
-  context "when running quieter" do
-    should "increase the verbosity threshold" do
+  describe "when running quieter" do
+    it "increases the verbosity threshold" do
       Einhorn::State.stubs(:verbosity => 1)
       Einhorn::State.expects(:verbosity=).once.with(2).returns(2)
       Command.quieter
     end
 
-    should "max out at 2" do
+    it "maxes out at 2" do
       Einhorn::State.stubs(:verbosity => 2)
       Einhorn::State.expects(:verbosity=).never
       Command.quieter

--- a/test/unit/einhorn/command/interface.rb
+++ b/test/unit/einhorn/command/interface.rb
@@ -1,12 +1,12 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../../../test_helper'))
+require File.expand_path(File.join(File.dirname(__FILE__), '../../../_lib'))
 
 require 'einhorn'
 
-class InterfaceTest < Test::Unit::TestCase
+class InterfaceTest < EinhornTestCase
   include Einhorn::Command
 
-  context "when a command is received" do
-    should "call that command" do
+  describe "when a command is received" do
+    it "calls that command" do
       conn = stub(:log_debug => nil)
       conn.expects(:write).once.with do |message|
         # Remove trailing newline
@@ -22,8 +22,8 @@ class InterfaceTest < Test::Unit::TestCase
     end
   end
 
-  context "when an unrecognized command is received" do
-    should "call the unrecognized_command method" do
+  describe "when an unrecognized command is received" do
+    it "calls the unrecognized_command method" do
       conn = stub(:log_debug => nil)
       Interface.expects(:unrecognized_command).once
       request = {
@@ -33,8 +33,8 @@ class InterfaceTest < Test::Unit::TestCase
     end
   end
 
-  context "when a worker ack is received" do
-    should "register ack and close the connection" do
+  describe "when a worker ack is received" do
+    it "registers ack and close the connection" do
       conn = stub(:log_debug => nil)
       conn.expects(:close).once
       conn.expects(:write).never

--- a/test/unit/einhorn/event.rb
+++ b/test/unit/einhorn/event.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../../test_helper'))
+require File.expand_path(File.join(File.dirname(__FILE__), '../../_lib'))
 
 require 'set'
 require 'einhorn'
@@ -13,17 +13,17 @@ module Einhorn::Event
   end
 end
 
-class EventTest < Test::Unit::TestCase
-  context "when running the event loop" do
-    setup do
+class EventTest < EinhornTestCase
+  describe "when running the event loop" do
+    before do
       Einhorn::Event.reset
     end
 
-    teardown do
+    after do
       Einhorn::Event.reset
     end
 
-    should "select on readable descriptors" do
+    it "selects on readable descriptors" do
       sock1 = mock(:fileno => 4)
       sock2 = mock(:fileno => 5)
 
@@ -40,7 +40,7 @@ class EventTest < Test::Unit::TestCase
       Einhorn::Event.loop_once
     end
 
-    should "select on writeable descriptors" do
+    it "selects on writeable descriptors" do
       sock1 = mock(:fileno => 4)
       sock2 = mock(:fileno => 5)
 
@@ -60,7 +60,7 @@ class EventTest < Test::Unit::TestCase
       Einhorn::Event.loop_once
     end
 
-    should "run callbacks for ready selectables" do
+    it "runs callbacks for ready selectables" do
       sock1 = mock(:fileno => 4)
       sock2 = mock(:fileno => 5)
 

--- a/test/unit/einhorn/worker_pool.rb
+++ b/test/unit/einhorn/worker_pool.rb
@@ -1,8 +1,8 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../../test_helper'))
+require File.expand_path(File.join(File.dirname(__FILE__), '../../_lib'))
 
 require 'einhorn'
 
-class WorkerPoolTest < Test::Unit::TestCase
+class WorkerPoolTest < EinhornTestCase
   def stub_children
     Einhorn::State.stubs(:children).returns(
       1234 => {:type => :worker, :signaled => Set.new(['INT'])},
@@ -11,12 +11,12 @@ class WorkerPoolTest < Test::Unit::TestCase
       )
   end
 
-  context "#workers_with_state" do
-    setup do
+  describe "#workers_with_state" do
+    before do
       stub_children
     end
 
-    should "select only the workers" do
+    it "selects only the workers" do
       workers_with_state = Einhorn::WorkerPool.workers_with_state
       # Sort only needed for Ruby 1.8
       assert_equal([
@@ -26,12 +26,12 @@ class WorkerPoolTest < Test::Unit::TestCase
     end
   end
 
-  context "#unsignaled_workers" do
-    setup do
+  describe "#unsignaled_workers" do
+    before do
       stub_children
     end
 
-    should "selects unsignaled workers" do
+    it "selects unsignaled workers" do
       unsignaled_workers = Einhorn::WorkerPool.unsignaled_workers
       assert_equal([1236], unsignaled_workers)
     end


### PR DESCRIPTION
I don't really understand what version constraints to put in place to make shoulda run on Ruby 1.8 anymre, and we've mostly settled on preferring minitest for new code, so I think the easiest thing is to convert einhorn to using minitest.

@gdb mind taking a look? It's mostly find/replaces (and a couple grammar corrections), and the tests seem to pass for me now.
