### PR TITLE
Allow to pass a command to execute via the command line

### DIFF
--- a/bin/einhornsh
+++ b/bin/einhornsh
@@ -21,14 +21,8 @@ module Einhorn
       emit('Type "quit" or "exit" to quit at any time')
 
       while line = Readline.readline('> ', true)
-        command, args = parse_command(line)
-        if ['quit', 'exit'].include?(command)
-          emit("Goodbye!")
-          return
-        end
-
         begin
-          response = @client.command({'command' => command, 'args' => args})
+          run_commandline(line)
         rescue Errno::EPIPE => e
           emit("einhornsh: Error communicating with Einhorn: #{e} (#{e.class})")
           emit("einhornsh: Attempting to reconnect...")
@@ -36,12 +30,22 @@ module Einhorn
 
           retry
         end
+      end
+    end
 
-        if response.kind_of?(Hash)
-          puts response['message']
-        else
-          puts "Invalid response type #{response.class}: #{response.inspect}"
-        end
+    def run_commandline(line)
+      command, args = parse_command(line)
+      if ['quit', 'exit'].include?(command)
+        emit("Goodbye!")
+        return
+      end
+
+      response = @client.command({'command' => command, 'args' => args})
+
+      if response.kind_of?(Hash)
+        puts response['message']
+      else
+        puts "Invalid response type #{response.class}: #{response.inspect}"
       end
     end
 
@@ -114,6 +118,10 @@ with a `-d`, provide the same argument here."
     opts.on('-d PATH', '--socket-path PATH', 'Path to the Einhorn command socket') do |path|
       options[:socket_path] = path
     end
+
+    opts.on('-r <commandline>', '--run <commandline>', 'Run the given commandline, i.e. -r "die SIGKILL"') do |command|
+      options[:commandline] = command
+    end
   end
   optparse.parse!
 
@@ -135,7 +143,11 @@ with a `-d`, provide the same argument here."
   end
 
   sh = Einhorn::EinhornSH.new(path_to_socket)
-  sh.run
+  if options[:commandline]
+    sh.run_commandline(options[:commandline])
+  else
+    sh.run
+  end
   return 0
 end
 


### PR DESCRIPTION
This allows you to do `einhornsh -r "die SIGKILL"` or similar when connected to the einhorn host over ssh, without having to enter the interactive shell.

/cc @gdb 
