### PR TITLE
einhornsh: Allow command execution outside of interactive shell

### DIFF
--- a/bin/einhornsh
+++ b/bin/einhornsh
@@ -45,20 +45,20 @@ module Einhorn
       emit
       emit('Type "quit" or "exit" to quit at any time')
 
-      while multiline = Readline.readline('> ', true)
-        run_line(multiline)
+      while command_line_sequence = Readline.readline('> ', true)
+        run_command_line_sequence(command_line_sequence)
       end
     end
 
-    def run_line(multiline)
-      lines = multiline.split(";")
-      lines.each do |line|
-        run_command(line)
+    def run_command_line_sequence(command_line_sequence)
+      command_lines = command_line_sequence.split(";")
+      command_lines.each do |command_line|
+        run_command_line(command_line)
       end
     end
 
-    def run_command(line)
-      command, args = parse_command(line)
+    def run_command_line(command_line)
+      command, args = parse_command_line(command_line)
       if command.nil?
         return
       elsif ['quit', 'exit'].include?(command)
@@ -74,8 +74,8 @@ module Einhorn
       @request_id += 1
     end
 
-    def parse_command(line)
-      command, *args = Shellwords.shellsplit(line)
+    def parse_command_line(command_line)
+      command, *args = Shellwords.shellsplit(command_line)
       [command, args]
     end
 
@@ -145,8 +145,8 @@ with a `-d`, provide the same argument here."
       options[:socket_path] = path
     end
 
-    opts.on('-e CMD', '--execute CMD', 'Execute this command outside of interactive mode') do |cmd|
-      options[:cmd] = cmd
+    opts.on('-e CMD_LINE_SEQ', '--execute CMD_LINE_SEQ', 'Execute this command outside of interactive mode') do |cmd_line_seq|
+      options[:cmd_line_seq] = cmd_line_seq
     end
 
   end
@@ -171,10 +171,10 @@ with a `-d`, provide the same argument here."
 
   sh = Einhorn::EinhornSH.new(path_to_socket)  
 
-  cmd = options[:cmd]
+  cmd_line_seq = options[:cmd_line_seq]
 
   begin
-    cmd ? sh.run_line(cmd) : sh.run
+    cmd_line_seq ? sh.run_command_line_sequence(cmd_line_seq) : sh.run
   rescue Einhorn::EinhornSH::EinhornSHExit => e
     return 0
   end


### PR DESCRIPTION
#### Commit summary

This commit does two things:
1. Allows commands to be executed outside of the Einhorn shell with `-e` or `--execute` to increment the number of workers.  
   Example: `einhornsh -e inc` will spin up the number of workers by one.
2. Allows the use of semicolons as command delimiters both in and out of the Einhorn shell.  
   Example: To spin up the number of workers by three, either `einhornsh -e "inc;inc;inc;"` outside of the shell or `inc;inc;inc;` inside the shell will work.
#### Edge cases
1. After splitting commands by semicolon, all empty commands are ignored.  
   Example: `inc;;;`, `; inc; ;`, and `inc` all increment the number of workers by one.
2. Any `quit` or `exit` before the end of a semicolon-delimited multi-command line returns from the shell, preventing later commands from running.  
   Example: `inc; exit; inc;`, `inc; quit; inc; inc;`, and `inc` all increment the number of workers by one.
