### PR TITLE
Modify thin example to use thin-attach_socket + EventMachine-LE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,8 @@
  eval(File.read(path), binding, path); break true
 end || source('https://rubygems.org/')
 
+# Only needed for examples
+gem 'thin-attach_socket'
+
 # Specify your gem's dependencies in einhorn.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -238,11 +238,8 @@ servers) to a wider array of applications.
 See https://stripe.com/blog/meet-einhorn for more background.
 
 Stripe currently uses Einhorn in production for a number of
-services. Our Thin + EventMachine servers currently require patches to
-both Thin and EventMachine (to support file-descriptor passing). You
-can obtain these patches from our public forks of the
-[respective](https://github.com/stripe/thin)
-[projects](https://github.com/stripe/eventmachine). Check out
+services. You can use Conrad Irwin's thin-attach_socket gem along with
+EventMachine-LE to support file-descriptor passing. Check out
 `example/thin_example` for an example of running Thin under Einhorn.
 
 ## Compatibility

--- a/example/thin_example
+++ b/example/thin_example
@@ -9,11 +9,9 @@
 require 'rubygems'
 require 'einhorn'
 
-# Make sure we're using the patched versions.
-gem 'thin', '1.3.2.stripe.0'
-gem 'eventmachine', '1.0.0.beta.4.stripe.0'
-
+require 'eventmachine-le'
 require 'thin'
+require 'thin/attach_socket'
 
 class App
   def initialize(id)
@@ -42,7 +40,9 @@ def einhorn_main
   EventMachine.run do
     (0...fd_count).each do |i|
       sock = Einhorn::Worker.socket!(i)
-      srv = Thin::Server.new(sock, App.new(i), :reuse => true)
+      srv = Thin::Server.new(App.new(i),
+        :backend => Thin::Backends::AttachSocket,
+        :socket => IO.for_fd(sock))
       srv.start
     end
   end


### PR DESCRIPTION
Also update the docs to point at those instead of our thin/EM patches.

With EventMachine-LE's support for attach_socket and Conrad's thin-attach_socket gem, we don't actually need patches to either Thin or EventMachine anymore.

It's possible we should still refer to our patches for posterity (though I'm inclined to say we shouldn't - they're distracting and discouraging), but I'm pretty sure our examples should work out-of-box with published upstream releases of gems, since that's a thing we have the capability to do now.

@nelhage, thoughts?
