### PR TITLE
Fix UNIXSocket leak

### DIFF
--- a/lib/einhorn/event.rb
+++ b/lib/einhorn/event.rb
@@ -75,7 +75,7 @@ module Einhorn
     def self.deregister_writeable(writer)
       writers = @@writeable[writer.to_io]
       writers.delete(writer)
-      @@readable.delete(writer.to_io) if writers.length == 0
+      @@writeable.delete(writer.to_io) if writers.length == 0
     end
 
     def self.writeable_fds


### PR DESCRIPTION
Due to a typo in the event loop code, references to writer IOs would be
kept around forever in the writer set, which prevented them from being
GC'd.
