### PR TITLE
Add a --signal-timeout option to escalate to SIGKILL.

### DIFF
--- a/bin/einhorn
+++ b/bin/einhorn
@@ -309,6 +309,10 @@ if true # $0 == __FILE__
       exit 0
     end
 
+    opts.on('--signal-timeout=T', '-t', 'If children do not react to signals after T seconds, escalate to SIGKILL') do |t|
+      Einhorn::State.signal_timeout = Integer(t)
+    end
+
     opts.on('--version', 'Show version') do
       puts Einhorn::VERSION
       exit

--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -78,6 +78,7 @@ module Einhorn
         :nice => {:master => nil, :worker => nil, :renice_cmd => '/usr/bin/renice'},
         :reexec_commandline => nil,
         :drop_environment_variables => [],
+        :signal_timeout => nil,
       }
     end
 


### PR DESCRIPTION
For many applications, it's appropriate to give workers the option to
gracefully exit, but to time out and escalate to SIGKILL if they
don't. This prevents misbehaving workers from blocking an upgrade or a
shutdown indefinitely.

r? @zenazn