### PR TITLE
Flush loglines atomically

### DIFF
--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -217,15 +217,15 @@ module Einhorn
 
   # Implement these ourselves so it plays nicely with state persistence
   def self.log_debug(msg, tag=nil)
-    $stderr.puts("#{log_tag} DEBUG: #{msg}") if Einhorn::State.verbosity <= 0
+    $stderr.puts("#{log_tag} DEBUG: #{msg}\n") if Einhorn::State.verbosity <= 0
     self.send_tagged_message(tag, msg) if tag
   end
   def self.log_info(msg, tag=nil)
-    $stderr.puts("#{log_tag} INFO: #{msg}") if Einhorn::State.verbosity <= 1
+    $stderr.puts("#{log_tag} INFO: #{msg}\n") if Einhorn::State.verbosity <= 1
     self.send_tagged_message(tag, msg) if tag
   end
   def self.log_error(msg, tag=nil)
-    $stderr.puts("#{log_tag} ERROR: #{msg}") if Einhorn::State.verbosity <= 2
+    $stderr.puts("#{log_tag} ERROR: #{msg}\n") if Einhorn::State.verbosity <= 2
     self.send_tagged_message(tag, "ERROR: #{msg}") if tag
   end
 


### PR DESCRIPTION
Ruby's IO#puts calls write(2) twice: once to write the string, and once
to write a newline. This means that other writes to the same file (in
other processes, for instance) might be interleaved between einhorn log
lines. If lines explicitly end in the newline character, however, Ruby
will omit its newline and thus the second call to write(2).