### PR TITLE
`state` command: Don't dump descriptors.

### DIFF
--- a/lib/einhorn/command/interface.rb
+++ b/lib/einhorn/command/interface.rb
@@ -305,7 +305,7 @@ EOF
     end
 
     command 'state', "Get a dump of Einhorn's current state" do
-      YAML.dump({state: Einhorn::State.dumpable_state})
+      YAML.dump({:state => Einhorn::State.dumpable_state})
     end
 
     command 'reload', 'Reload Einhorn' do |conn, request|

--- a/lib/einhorn/command/interface.rb
+++ b/lib/einhorn/command/interface.rb
@@ -305,7 +305,7 @@ EOF
     end
 
     command 'state', "Get a dump of Einhorn's current state" do
-      YAML.dump(Einhorn::Command.dumpable_state)
+      YAML.dump({state: Einhorn::State.dumpable_state})
     end
 
     command 'reload', 'Reload Einhorn' do |conn, request|


### PR DESCRIPTION
These are an internal implementation detail and not unlikely to be
useful to clients (we currently have no users), and having this in the
`state` output risks an exponential explosion in the size of the
serialized state, in the event of multiple concurrent `state`
commands (since the descriptor representing the `einhornsh` client will
contain a complete copy of the YAML-encoded previous state).

r? @zenazn
cc @ebroder