### PR TITLE
Allow binding UNIX domain sockets

### DIFF
--- a/bin/einhorn
+++ b/bin/einhorn
@@ -53,7 +53,11 @@ arguments:
 
 Each address is specified as an ip/port pair, possibly accompanied by options:
 
-    ADDR := (IP:PORT)[<,OPT>...]
+    IP_ADDR := (IP:PORT)[<,OPT>...]
+
+or as a path to a UNIX domain socket, also possibly accompanied by options:
+
+    UNIX_ADDR := /path/to/socket[<,OPT>...]
 
 In the worker process, the opened file descriptors will be represented
 as file descriptor numbers in a series of environment variables named
@@ -181,6 +185,20 @@ EOF
   end
 end
 
+
+BIND_PATTERN = /\A
+  # we accept two types of socket address
+  (?:
+    # ip, host:port
+    (?:(?<host>[^:]+):(?<port>\d+)) |
+    # unix socket path
+    (?<path>[^,:]+)
+  )
+
+  # flags are optional, comma delimited, and come at the end
+  (?<flags>(?:,\w+)*)
+\Z/x
+
 # Would be nice if this could be loadable rather than always
 # executing, but when run under gem it's a bit hard to do so.
 if true # $0 == __FILE__
@@ -190,14 +208,19 @@ if true # $0 == __FILE__
 
   optparse = OptionParser.new do |opts|
     opts.on('-b ADDR', '--bind ADDR', 'Bind an address and add the corresponding FD via the environment') do |addr|
-      unless addr =~ /\A([^:]+):(\d+)((?:,\w+)*)\Z/
-        raise "Invalid value for #{addr.inspect}: bind address must be of the form address:port[,flags...]"
+      unless addr =~ BIND_PATTERN
+        raise "Invalid value for #{addr.inspect}: bind address must be of the form address:port[,flags...] or /path/to/unix/socket[,flags...]"
       end
 
-      host = $1
-      port = Integer($2)
-      flags = $3.split(',').select {|flag| flag.length > 0}.map {|flag| flag.downcase}
-      Einhorn::State.bind << [host, port, flags]
+      flags = $~["flags"].split(",").reject(&:empty?).map(&:downcase)
+
+      bind = if $~["path"]
+        Einhorn::Bind::UnixBind.new($~["path"], flags)
+      else
+        Einhorn::Bind::InetBind.new($~["host"], Integer($~["port"]), flags)
+      end
+
+      Einhorn::State.bind << bind
     end
 
     opts.on('-c CMD_NAME', '--command-name CMD_NAME', 'Set the command name in ps to this value') do |cmd_name|

--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -142,6 +142,17 @@ module Einhorn
           dead.each {|pid| Einhorn::Command.mourn(pid)}
         end
       end
+
+      if updated_state[:bind]
+        updated_state[:bind].map! do |binding|
+          # bindings used to just be arrays of [host,port,flags]
+          if binding.is_a? Array
+            Bind::InetBind.new(*binding)
+          else
+            binding
+          end
+        end
+      end
     end
 
     default = store.default_state
@@ -164,19 +175,16 @@ module Einhorn
     log_info(Einhorn::State.state.pretty_inspect)
   end
 
-  def self.bind(addr, port, flags)
-    log_info("Binding to #{addr}:#{port} with flags #{flags.inspect}")
-    sd = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
+  def self.bind(binding)
+    log_info("Binding to #{binding.address} with flags #{binding.flags.inspect}")
+
+    sd = binding.make_socket()
     Einhorn::Compat.cloexec!(sd, false)
 
-    if flags.include?('r') || flags.include?('so_reuseaddr')
-      sd.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, 1)
-    end
-
-    sd.bind(Socket.pack_sockaddr_in(port, addr))
+    binding.bind(sd)
     sd.listen(Einhorn::State.config[:backlog])
 
-    if flags.include?('n') || flags.include?('o_nonblock')
+    if binding.flags.include?('n') || binding.flags.include?('o_nonblock')
       fl = sd.fcntl(Fcntl::F_GETFL)
       sd.fcntl(Fcntl::F_SETFL, fl | Fcntl::O_NONBLOCK)
     end
@@ -323,8 +331,8 @@ module Einhorn
   end
 
   def self.socketify_env!
-    Einhorn::State.bind.each do |host, port, flags|
-      fd = bind(host, port, flags)
+    Einhorn::State.bind.each do |binding|
+      fd = bind(binding)
       Einhorn::State.bind_fds << fd
     end
   end
@@ -339,7 +347,8 @@ module Einhorn
         host = $2
         port = $3
         flags = $4.split(',').select {|flag| flag.length > 0}.map {|flag| flag.downcase}
-        fd = (Einhorn::State.sockets[[host, port]] ||= bind(host, port, flags))
+        binding = Bind::InetBind.new(host, port, flags)
+        fd = (Einhorn::State.sockets[[host, port]] ||= bind(binding))
         "#{opt}#{fd}"
       else
         arg
@@ -445,6 +454,7 @@ module Einhorn
   end
 end
 
+require 'einhorn/bind'
 require 'einhorn/command'
 require 'einhorn/compat'
 require 'einhorn/client'

--- a/lib/einhorn/bind.rb
+++ b/lib/einhorn/bind.rb
@@ -1,0 +1,97 @@
+require 'socket'
+
+module Einhorn::Bind
+  class Bind
+    attr_reader :flags
+
+    def ==(o)
+      o.class == self.class && o.state == state
+    end
+  end
+
+  class InetBind < Bind
+    def initialize(host, port, flags)
+      @host = host
+      @port = port
+      @flags = flags
+    end
+
+    def state
+      [@host, @port, @flags]
+    end
+
+    def family
+      "AF_INET"
+    end
+
+    def address
+      "#{@host}:#{@port}"
+    end
+
+    def make_socket
+      sd = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
+
+      if @flags.include?('r') || @flags.include?('so_reuseaddr')
+        sd.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, 1)
+      end
+
+      sd
+    end
+
+    def bind(sock)
+      sock.bind(Socket.pack_sockaddr_in(@port, @host))
+    end
+  end
+
+  class UnixBind < Bind
+    def initialize(path, flags)
+      @path = path
+      @flags = flags
+    end
+
+    def state
+      [@path, @flags]
+    end
+
+    def family
+      "AF_UNIX"
+    end
+
+    def address
+      "#{@path}"
+    end
+
+    def make_socket
+      Socket.new(Socket::AF_UNIX, Socket::SOCK_STREAM, 0)
+    end
+
+    def clean_old_unix_socket
+      begin
+        sock = UNIXSocket.new(@path)
+      rescue Errno::ECONNREFUSED
+        # This happens with non-socket files and when the listening
+        # end of a socket has exited.
+      rescue Errno::ENOENT
+        # Socket doesn't exist
+        return
+      else
+        # Rats, it's still active
+        sock.close
+        raise Errno::EADDRINUSE.new("Another process is listening on the UNIX socket at #{@path}. If you'd like to run this Einhorn as well, pass a `-b PATH_TO_SOCKET` to change the socket location.")
+      end
+
+      stat = File.stat(@path)
+      unless stat.socket?
+        raise Errno::EADDRINUSE.new("Non-socket file present at UNIX socket path #{@path}. Either remove that file and restart Einhorn, or pass a different `-b PATH_TO_SOCKET` to change where you are binding.")
+      end
+
+      Einhorn.log_info("Blowing away old UNIX socket at #{@path}. This likely indicates a previous Einhorn master which exited uncleanly.")
+      File.unlink(@path)
+    end
+
+    def bind(sock)
+      self.clean_old_unix_socket
+      sock.bind(Socket.pack_sockaddr_un(@path))
+    end
+  end
+end

--- a/lib/einhorn/command.rb
+++ b/lib/einhorn/command.rb
@@ -323,6 +323,7 @@ module Einhorn
 
       ENV['EINHORN_FD_COUNT'] = Einhorn::State.bind_fds.length.to_s
       Einhorn::State.bind_fds.each_with_index {|fd, i| ENV["EINHORN_FD_#{i}"] = fd.to_s}
+      Einhorn::State.bind.each_with_index {|bind, i| ENV["EINHORN_FD_FAMILY_#{i}"] = bind.family}
 
       ENV['EINHORN_CHILD_INDEX'] = index.to_s
 

--- a/test/unit/einhorn.rb
+++ b/test/unit/einhorn.rb
@@ -10,7 +10,7 @@ class EinhornTest < EinhornTestCase
 
     it "correctly parses srv: arguments" do
       cmd = ['foo', 'srv:1.2.3.4:123,llama,test', 'bar']
-      Einhorn.expects(:bind).once.with('1.2.3.4', '123', ['llama', 'test']).returns(4)
+      Einhorn.expects(:bind).once.with(Einhorn::Bind::InetBind.new('1.2.3.4', '123', ['llama', 'test'])).returns(4)
 
       Einhorn.socketify!(cmd)
 
@@ -19,7 +19,7 @@ class EinhornTest < EinhornTestCase
 
     it "correctly parses --opt=srv: arguments" do
       cmd = ['foo', '--opt=srv:1.2.3.4:456', 'baz']
-      Einhorn.expects(:bind).once.with('1.2.3.4', '456', []).returns(5)
+      Einhorn.expects(:bind).once.with(Einhorn::Bind::InetBind.new('1.2.3.4', '456', [])).returns(5)
 
       Einhorn.socketify!(cmd)
 
@@ -28,7 +28,7 @@ class EinhornTest < EinhornTestCase
 
     it "uses the same fd number for the same server spec" do
       cmd = ['foo', '--opt=srv:1.2.3.4:8910', 'srv:1.2.3.4:8910']
-      Einhorn.expects(:bind).once.with('1.2.3.4', '8910', []).returns(10)
+      Einhorn.expects(:bind).once.with(Einhorn::Bind::InetBind.new('1.2.3.4', '8910', [])).returns(10)
 
       Einhorn.socketify!(cmd)
 


### PR DESCRIPTION
As mentioned in #58, this adds support for bound sockets being UNIX domain sockets. This is something that I needed for an application on our end and think might be generally useful. This works by extending the regex in argument parsing to accept filenames that don't have colons in them as UNIX domain sockets. The `state.bind` stuff is then modified to be inet or unix bind objects which abstracts out the logic of how to create/bind each type of socket properly. If binding the socket results in `EADDRINUSE`, we'll do the connect, stat, unlink dance to try and clean up old dead sockets. The address family is added to the child environment for each socket so that workers can know which family to bind with more easily.

Issues/questions:
- ~~I can't get the tests to run locally without errors with or without this patch, so I'm not clear on their status. Will check with Travis once that runs.~~ It looks like the tests are failing to install packages etc. on various versions, but where they install everything is checking out.
- There's some duplication between the command socket binding/cleanup code and the unix socket cleanup code in this patch. I wasn't clear how I could de-duplicate this and maintain the descriptive error messages.
- I'm not super fond of the bind.rb file or how that stuff is structured, if you've any alternatives I'm all ears.
- I've tested in place upgrades but there might be more cases I'm not thinking about there.
