### PR TITLE
Launch children in a new process group.

### DIFF
--- a/einhorn.gemspec
+++ b/einhorn.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
   gem.name          = 'einhorn'
   gem.require_paths = ['lib']
 
+  gem.add_development_dependency 'rack', '~> 1.6'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'minitest', '< 5.0'

--- a/lib/einhorn/command.rb
+++ b/lib/einhorn/command.rb
@@ -364,6 +364,7 @@ module Einhorn
     end
 
     def self.prepare_child_process
+      Process.setpgrp
       Einhorn.renice_self
     end
 


### PR DESCRIPTION
This has the effect that, when einhorn is run interactively, signals
sent by the terminal (e.g. in response to ^C) only go to the einhorn
master, and not to any of its children.

r? @zenazn