### PR TITLE
Demote client connection log lines to debug

### DIFF
--- a/lib/einhorn/event/connection.rb
+++ b/lib/einhorn/event/connection.rb
@@ -57,13 +57,13 @@ module Einhorn::Event
     end
 
     def register!
-      log_info("client connected")
+      log_debug("client connected")
       Einhorn::Event.register_connection(self, @socket.fileno)
       super
     end
 
     def deregister!
-      log_info("client disconnected") if Einhorn::TransientState.whatami == :master
+      log_debug("client disconnected") if Einhorn::TransientState.whatami == :master
       Einhorn::Event.deregister_connection(@socket.fileno)
       super
     end


### PR DESCRIPTION
I can't think of any cases where these log lines are useful, and they can be quite noisy.

r? @raylu 
cc @nelhage @zenazn in case either of you have feelings