### PR TITLE
set pdeathsig in workers when run with `-k`

### DIFF
--- a/einhorn.gemspec
+++ b/einhorn.gemspec
@@ -23,7 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'chalk-rake'
   gem.add_development_dependency 'subprocess'
 
-  gem.add_runtime_dependency 'ffi'
-
   gem.version       = Einhorn::VERSION
 end

--- a/einhorn.gemspec
+++ b/einhorn.gemspec
@@ -23,5 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'chalk-rake'
   gem.add_development_dependency 'subprocess'
 
+  gem.add_runtime_dependency 'ffi'
+
   gem.version       = Einhorn::VERSION
 end

--- a/lib/einhorn/prctl.rb
+++ b/lib/einhorn/prctl.rb
@@ -1,0 +1,26 @@
+module Einhorn
+  class PrctlAbstract
+    def self.get_pdeathsig
+      raise NotImplementedError
+    end
+
+    def self.set_pdeathsig(signal)
+      raise NotImplementedError
+    end
+  end
+
+  class PrctlUnimplemented < PrctlAbstract
+    # Deliberately empty; NotImplementedError is intended
+  end
+
+  Prctl = PrctlUnimplemented
+
+  if RUBY_PLATFORM =~ /linux/ then
+    begin
+      require 'einhorn/prctl_linux'
+      Prctl = PrctlLinux
+    rescue LoadError
+      # Do nothing
+    end
+  end
+end

--- a/lib/einhorn/prctl.rb
+++ b/lib/einhorn/prctl.rb
@@ -13,14 +13,14 @@ module Einhorn
     # Deliberately empty; NotImplementedError is intended
   end
 
-  Prctl = PrctlUnimplemented
-
   if RUBY_PLATFORM =~ /linux/ then
     begin
       require 'einhorn/prctl_linux'
       Prctl = PrctlLinux
     rescue LoadError
-      # Do nothing
+      Prctl = PrctlUnimplemented
     end
+  else
+    Prctl = PrctlUnimplemented
   end
 end

--- a/lib/einhorn/prctl_linux.rb
+++ b/lib/einhorn/prctl_linux.rb
@@ -1,0 +1,42 @@
+require 'ffi'
+
+module Einhorn
+  class PrctlLinux < PrctlAbstract
+    extend FFI::Library
+    ffi_lib FFI::Library::LIBC
+    enum :option, [
+      :set_pdeathsig, 1,
+      :get_pdeathsig, 2,
+    ]
+    attach_function :prctl, [ :option, :ulong, :ulong, :ulong, :ulong ], :int
+
+    def self.get_pdeathsig
+      out = FFI::MemoryPointer.new(:int, 1)
+      if prctl(:get_pdeathsig, out.address, 0, 0, 0) != 0 then
+        raise SystemCallError.new("get_pdeathsig", FFI.errno)
+      end
+
+      signo = out.get_int(0)
+      if signo == 0 then
+        return nil
+      end
+
+      return Signal.signame(signo)
+    end
+
+    def self.set_pdeathsig(signal)
+      case
+      when signal == nil
+        signo = 0
+      when signal.instance_of?(String)
+        signo = Signal.list.fetch(signal)
+      else
+        signo = signal
+      end
+
+      if prctl(:set_pdeathsig, signo, 0, 0, 0) != 0 then
+        raise SystemCallError.new("set_pdeathsig(#{signal})", FFI.errno)
+      end
+    end
+  end
+end

--- a/test/integration/_lib/fixtures/pdeathsig_printer/pdeathsig_printer.rb
+++ b/test/integration/_lib/fixtures/pdeathsig_printer/pdeathsig_printer.rb
@@ -1,0 +1,29 @@
+require 'bundler/setup'
+require 'socket'
+require 'einhorn/worker'
+require 'einhorn/prctl'
+
+def einhorn_main
+  serv = Socket.for_fd(Einhorn::Worker.socket!)
+
+  Signal.trap("USR2") { exit }
+
+  begin
+    output = Einhorn::Prctl.get_pdeathsig
+    if output == nil then
+      output = "nil"
+    end
+  rescue NotImplementedError
+    output = "not implemented"
+  end
+
+  Einhorn::Worker.ack!
+  while true
+    s, _ = serv.accept
+    s.write(output)
+    s.flush
+    s.close
+  end
+end
+
+einhorn_main if $0 == __FILE__

--- a/test/integration/pdeathsig.rb
+++ b/test/integration/pdeathsig.rb
@@ -1,0 +1,26 @@
+require(File.expand_path('_lib', File.dirname(__FILE__)))
+
+class PdeathsigTest < EinhornIntegrationTestCase
+  include Helpers::EinhornHelpers
+
+  describe 'when run with -k' do
+    before do
+      @dir = prepare_fixture_directory('pdeathsig_printer')
+      @port = find_free_port
+      @server_program = File.join(@dir, 'pdeathsig_printer.rb')
+      @socket_path = File.join(@dir, 'einhorn.sock')
+    end
+    after { cleanup_fixtured_directories }
+
+    it 'sets pdeathsig to USR2 in the child process' do
+      with_running_einhorn(%W{einhorn -m manual -b 127.0.0.1:#{@port} -d #{@socket_path} -k -- ruby #{@server_program}}) do |process|
+        wait_for_open_port
+        output = read_from_port
+        if output != "not implemented" then
+          assert_equal("USR2", output)
+        end
+        process.terminate
+      end
+    end
+  end
+end


### PR DESCRIPTION
When the einhorn master is sent a `SIGKILL`, for example by the OOM killer, its child processes stick around even if einhorn was run with `--kill-children-on-exit` (which is documented to gracefully kill its workers if einhorn exits unexpectedly.)

There's an unfixable race condition in this code for one ruby VM instruction's time; see the comments in `lib/einhorn/command.rb:setup_parent_watch`.

I don't like that I require the `ffi` gem on all platforms since the `ffi` gem is only needed on Linux (and even there, it's optional), but I don't know of a nice solution to that and figured it'd be better to leave hacks out of the gemspec file.

r? @raylu-stripe 
cc @stripe-internal/sys