### PR TITLE
Ensure stuck workers are killed

### DIFF
--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -411,6 +411,14 @@ module Einhorn
       Einhorn::State.reloading_for_upgrade = false
     end
 
+    # If setting a signal-timeout, timeout the event loop
+    # in the same timeframe, ensuring processes are culled
+    # on a regular basis.
+    if Einhorn::State.signal_timeout
+      Einhorn::Event.default_timeout = Einhorn::Event.default_timeout.nil? ?
+        Einhorn::State.signal_timeout : [Einhorn::State.signal_timeout, Einhorn::Event.default_timeout].min
+    end
+
     while Einhorn::State.respawn || Einhorn::State.children.size > 0
       log_debug("Entering event loop")
 

--- a/lib/einhorn/event.rb
+++ b/lib/einhorn/event.rb
@@ -4,6 +4,7 @@ module Einhorn
   module Event
     @@loopbreak_reader = nil
     @@loopbreak_writer = nil
+    @@default_timeout = nil
     @@signal_actions = []
     @@readable = {}
     @@writeable = {}
@@ -120,7 +121,7 @@ module Einhorn
       if expires_at = @@timers.keys.sort[0]
         expires_at - Time.now
       else
-        nil
+        @@default_timeout
       end
     end
 
@@ -164,6 +165,14 @@ module Einhorn
       rescue Errno::EWOULDBLOCK, Errno::EAGAIN
         Einhorn.log_error("Loop break pipe is full -- probably means that we are quite backlogged")
       end
+    end
+
+    def self.default_timeout=(val)
+      @@default_timeout = val.to_i == 0 ? nil : val.to_i
+    end
+
+    def self.default_timeout
+      @@default_timeout
     end
   end
 end

--- a/lib/einhorn/version.rb
+++ b/lib/einhorn/version.rb
@@ -1,3 +1,3 @@
 module Einhorn
-  VERSION = '0.7.5'
+  VERSION = '0.7.6'
 end

--- a/test/integration/_lib/fixtures/signal_timeout/sleepy_server.rb
+++ b/test/integration/_lib/fixtures/signal_timeout/sleepy_server.rb
@@ -1,0 +1,22 @@
+require 'bundler/setup'
+require 'socket'
+require 'einhorn/worker'
+
+def einhorn_main
+  serv = Socket.for_fd(Einhorn::Worker.socket!)
+  Einhorn::Worker.ack!
+
+  Signal.trap('USR2') do
+    sleep ENV.fetch("TRAP_SLEEP").to_i
+    exit
+  end
+
+  while true
+    s, _ = serv.accept
+    s.write($$)
+    s.flush
+    s.close
+  end
+end
+
+einhorn_main if $0 == __FILE__

--- a/test/integration/_lib/helpers/einhorn_helpers.rb
+++ b/test/integration/_lib/helpers/einhorn_helpers.rb
@@ -106,6 +106,11 @@ module Helpers
       open_port.close
     end
 
+    def get_state(client)
+      client.send_command('command' => 'state')
+      YAML.load(client.receive_message['message'])[:state]
+    end
+
     def wait_for_open_port
       max_retries = 50
       begin

--- a/test/integration/upgrading.rb
+++ b/test/integration/upgrading.rb
@@ -166,8 +166,8 @@ class UpgradeTests < EinhornIntegrationTestCase
     after { cleanup_fixtured_directories }
 
     it 'issues a SIGKILL to outdated children when signal-timeout has passed' do
-      signal_timeout = 3
-      sleep_for = 5
+      signal_timeout = 2
+      sleep_for = 10
       cmd = %W{
         einhorn
         -b 127.0.0.1:#{@port}
@@ -186,7 +186,7 @@ class UpgradeTests < EinhornIntegrationTestCase
         signaled_children = state[:children].select{|_,c| c[:signaled].length > 0}
         assert_equal(1, signaled_children.length)
 
-        sleep(signal_timeout + 1)
+        sleep(signal_timeout * 2)
 
         state = get_state(client)
         assert_equal(1, state[:children].count)


### PR DESCRIPTION
## What's the problem?

There is a rare case where after an upgrade, a worker will become stuck after being issued a USR2. If the signal_timeout timer doesn't fire for some reason, the child will remain running forever with an old version.

## What's the fix?

This new behaviour adds another stage to `cull` where it will periodically check if any previously upgraded (read: signaled with `USR2`) are running longer than `signal-timeout` and, if so, terminates them with `KILL`.

One of the broader changes here is setting the IO read/write timeout to the same value as `signal-timeout` so that the read doesn't block forever and the `reap/replenish/cull` gets hit periodically.

This should ensure that any old upgraded workers are short lived.