### PR TITLE
flush stderr whenever einhorn logs a line

### DIFF
--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -168,14 +168,17 @@ module Einhorn
   # Implement these ourselves so it plays nicely with state persistence
   def self.log_debug(msg, tag=nil)
     $stderr.puts("#{log_tag} DEBUG: #{msg}\n") if Einhorn::State.verbosity <= 0
+    $stderr.flush
     self.send_tagged_message(tag, msg) if tag
   end
   def self.log_info(msg, tag=nil)
     $stderr.puts("#{log_tag} INFO: #{msg}\n") if Einhorn::State.verbosity <= 1
+    $stderr.flush
     self.send_tagged_message(tag, msg) if tag
   end
   def self.log_error(msg, tag=nil)
     $stderr.puts("#{log_tag} ERROR: #{msg}\n") if Einhorn::State.verbosity <= 2
+    $stderr.flush
     self.send_tagged_message(tag, "ERROR: #{msg}") if tag
   end
 


### PR DESCRIPTION
So we had a really weird thing happen where our log system ingested einhorn's "Sending SIGTERM..." line upon signaling its children to exit gracefully, but it did so *long* after the children exited due to those SIGTERMs. So, our logs are out of order!

I strongly suspect that the line was output when einhorn finally exited (as opposed to when it meant to say that it's sending SIGTERMs), and that might potentially point to output buffering as a culprit. So! This PR adds `$stderr.flush` to each logging method, which should ensure that whenever a line gets logged, ruby flushes any stderr buffer.