### PR TITLE
Release 0.7.7

### DIFF
--- a/lib/einhorn/version.rb
+++ b/lib/einhorn/version.rb
@@ -1,3 +1,3 @@
 module Einhorn
-  VERSION = '0.7.6'
+  VERSION = '0.7.7'
 end


### PR DESCRIPTION
This PR only bumps the version to 0.7.7. 

There was some confusion about the provenance of 0.7.6, so I think it's best if we skip this version and just release 0.7.7.