### PR TITLE
Added --max-unacked to control the maximum number of unacked

### DIFF
--- a/bin/einhorn
+++ b/bin/einhorn
@@ -310,6 +310,10 @@ if true # $0 == __FILE__
       Einhorn::State.signal_timeout = Integer(t)
     end
 
+    opts.on('--max-unacked=N', 'Maximum number of workers that can be unacked when gracefully upgrading.') do |n|
+      Einhorn::State.config[:max_unacked] = Integer(n)
+    end
+
     opts.on('--version', 'Show version') do
       puts Einhorn::VERSION
       exit

--- a/lib/einhorn/command.rb
+++ b/lib/einhorn/command.rb
@@ -563,6 +563,8 @@ module Einhorn
       return if Einhorn::TransientState.has_outstanding_spinup_timer
       return unless Einhorn::WorkerPool.missing_worker_count > 0
 
+      max_unacked ||= Einhorn::State.config[:max_unacked]
+
       # default to spinning up at most NCPU workers at once
       unless max_unacked
         begin


### PR DESCRIPTION
The maximum number of unacked workers is based on CPU, and there's no way to reconfigure it. This is a bit problematic on hosts with lot of CPUs available, but not a lot of comparative memory since trying to do an upgrade can cause you to OOM in some scenarios.

It looks like this area of code doesn't actually have tests as far as I can tell. If I missed something existing, let me know.