### PR TITLE
Support Symlinks

### DIFF
--- a/lib/einhorn/compat.rb
+++ b/lib/einhorn/compat.rb
@@ -25,6 +25,10 @@ module Einhorn
 
     # Opts are ignored in Ruby 1.8
     def self.exec(script, args, opts={})
+      if start_pwd = ENV["SYMLINK"]
+        opts[:chdir] ||= start_pwd
+      end
+
       cmd = [script, script]
       begin
         Kernel.exec(cmd, *(args + [opts]))


### PR DESCRIPTION
My team and I use einhorn to run our [Sidekiq processes](https://github.com/mperham/sidekiq/wiki/Ent-Rolling-Restarts#how). We have found when using this with our Capistrano like deploy process that when the initial directory used to boot Sidekiq ages out and gets removed that the einhorn upgrade fails because of the missing directory. 

This will allow users to set a symlink path using an ENV variable that can be used when running einhorn. Then when an upgrade happens einhorn will use the symlink to find the new directory. Initially, I tried using the ENV variable `PWD` but I found that with our systemd setup that the `PWD` ENV variable was resolved to the symlink'ed directory by the time the exec command in einhorn was run.

Confirmed locally that all specs run green. 