### PR TITLE
Adding blurb for project status being in maintenance mode only

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,14 @@ Then you could set `--reexec-as=` to the name of your bash script and it will ru
 
 ## Contributing
 
+### Development Status
+
+Einhorn is still in active operation at Stripe, but we are not maintaining
+Einhorn actively. PRs are very welcome, and we will review and merge,
+but we are unlikely to triage and fix reported issues without code.
+
 Contributions are definitely welcome. To contribute, just follow the
-usual workflow:
+sual workflow:
 
 1. Fork Einhorn
 2. Create your feature branch (`git checkout -b my-new-feature`)

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Einhorn actively. PRs are very welcome, and we will review and merge,
 but we are unlikely to triage and fix reported issues without code.
 
 Contributions are definitely welcome. To contribute, just follow the
-sual workflow:
+usual workflow:
 
 1. Fork Einhorn
 2. Create your feature branch (`git checkout -b my-new-feature`)


### PR DESCRIPTION
Stripe is not actively investing in new work on Einhorn, just fixing bugs and triaging. Updated the README to illustrate this!

r? @zanker-stripe 