### PR TITLE
Add ping with request ID to Einhorn

### DIFF
--- a/lib/einhorn/command.rb
+++ b/lib/einhorn/command.rb
@@ -47,6 +47,16 @@ module Einhorn
       end
     end
 
+    def self.register_ping(pid, request_id)
+      unless spec = Einhorn::State.children[pid]
+        Einhorn.log_error("Could not find state for PID #{pid.inspect}; ignoring ACK.")
+        return
+      end
+
+      spec[:pinged_at] = Time.now
+      spec[:pinged_request_id] = request_id
+    end
+
     def self.register_manual_ack(pid)
       ack_mode = Einhorn::State.ack_mode
       unless ack_mode[:type] == :manual

--- a/lib/einhorn/command/interface.rb
+++ b/lib/einhorn/command/interface.rb
@@ -289,6 +289,17 @@ EOF
       nil
     end
 
+    command 'worker:ping' do |conn, request|
+      if pid = request['pid']
+        Einhorn::Command.register_ping(pid, request['request_id'])
+      else
+        conn.log_error("Invalid request (no pid): #{request.inspect}")
+      end
+      # Throw away this connection in case the application forgets to
+      conn.close
+      nil
+    end
+
     # Used by einhornsh
     command 'ehlo' do |conn, request|
       <<EOF

--- a/lib/einhorn/version.rb
+++ b/lib/einhorn/version.rb
@@ -1,3 +1,3 @@
 module Einhorn
-  VERSION = '0.7.10'
+  VERSION = '0.7.11'
 end

--- a/lib/einhorn/worker.rb
+++ b/lib/einhorn/worker.rb
@@ -66,33 +66,28 @@ module Einhorn
     # be useful for anything. Maybe if it's always fd 3, because then
     # the user wouldn't have to provide an arg.
     def self.ack!(discovery=:env, arg=nil)
-      ensure_worker!
-      close_after_use = true
-
-      case discovery
-      when :env
-        socket = ENV['EINHORN_SOCK_PATH']
-        client = Einhorn::Client.for_path(socket)
-      when :fd
-        raise "No EINHORN_SOCK_FD provided in environment. Did you run einhorn with the -g flag?" unless fd_str = ENV['EINHORN_SOCK_FD']
-
-        fd = Integer(fd_str)
-        client = Einhorn::Client.for_fd(fd)
-        close_after_use = false if arg
-      when :direct
-        socket = arg
-        client = Einhorn::Client.for_path(socket)
-      else
-        raise "Unrecognized socket discovery mechanism: #{discovery.inspect}. Must be one of :filesystem, :argv, or :direct"
+      handle_command_socket(discovery, arg) do |client|
+        client.send_command('command' => 'worker:ack', 'pid' => $$)
       end
+    end
 
-      client.send_command({
-          'command' => 'worker:ack',
-          'pid' => $$
-        })
-
-      client.close if close_after_use
-      true
+    # Call this to indicate your child process is up and in a healthy state.
+    # Arguments:
+    #
+    # @request_id: Identifies the request ID of the worker, can be used to debug wedged workers.
+    #
+    # @discovery: How to discover the master process's command socket.
+    #   :env:        Discover the path from ENV['EINHORN_SOCK_PATH']
+    #   :fd:         Just use the file descriptor in ENV['EINHORN_SOCK_FD'].
+    #                Must run the master with the -g flag. This is mostly
+    #                useful if you don't have a nice library like Einhorn::Worker.
+    #                Then @arg being true causes the FD to be left open after ACK;
+    #                otherwise it is closed.
+    #   :direct:     Provide the path to the command socket in @arg.
+    def self.ping!(request_id, discovery=:env, arg=nil)
+      handle_command_socket(discovery, arg) do |client|
+        client.send_command('command' => 'worker:ping', 'pid' => $$, 'request_id' => request_id)
+      end
     end
 
     def self.socket(number=nil)
@@ -138,6 +133,33 @@ module Einhorn
     end
 
     private
+
+    def self.handle_command_socket(discovery, contextual_arg)
+      ensure_worker!
+      close_after_use = true
+
+      case discovery
+      when :env
+        socket = ENV['EINHORN_SOCK_PATH']
+        client = Einhorn::Client.for_path(socket)
+      when :fd
+        raise "No EINHORN_SOCK_FD provided in environment. Did you run einhorn with the -g flag?" unless fd_str = ENV['EINHORN_SOCK_FD']
+
+        fd = Integer(fd_str)
+        client = Einhorn::Client.for_fd(fd)
+        close_after_use = false if arg
+      when :direct
+        socket = arg
+        client = Einhorn::Client.for_path(socket)
+      else
+        raise "Unrecognized socket discovery mechanism: #{discovery.inspect}. Must be one of :filesystem, :argv, or :direct"
+      end
+
+      yield client
+      client.close if close_after_use
+
+      true
+    end
 
     def self.socket_from_filesystem(cmd_name)
       ppid = Process.ppid

--- a/lib/einhorn/worker.rb
+++ b/lib/einhorn/worker.rb
@@ -147,9 +147,9 @@ module Einhorn
 
         fd = Integer(fd_str)
         client = Einhorn::Client.for_fd(fd)
-        close_after_use = false if arg
+        close_after_use = false if contextual_arg
       when :direct
-        socket = arg
+        socket = contextual_arg
         client = Einhorn::Client.for_path(socket)
       else
         raise "Unrecognized socket discovery mechanism: #{discovery.inspect}. Must be one of :filesystem, :argv, or :direct"

--- a/test/integration/_lib/fixtures/exit_during_upgrade/exiting_server.rb
+++ b/test/integration/_lib/fixtures/exit_during_upgrade/exiting_server.rb
@@ -5,6 +5,7 @@ require 'einhorn/worker'
 def einhorn_main
   serv = Socket.for_fd(Einhorn::Worker.socket!)
   Einhorn::Worker.ack!
+  Einhorn::Worker.ping!("id-1")
 
   Signal.trap('USR2') do
     sleep 3

--- a/test/integration/_lib/fixtures/signal_timeout/sleepy_server.rb
+++ b/test/integration/_lib/fixtures/signal_timeout/sleepy_server.rb
@@ -5,6 +5,7 @@ require 'einhorn/worker'
 def einhorn_main
   serv = Socket.for_fd(Einhorn::Worker.socket!)
   Einhorn::Worker.ack!
+  Einhorn::Worker.ping!("id-1")
 
   Signal.trap('USR2') do
     sleep ENV.fetch("TRAP_SLEEP").to_i

--- a/test/integration/_lib/fixtures/upgrade_project/upgrading_server.rb
+++ b/test/integration/_lib/fixtures/upgrade_project/upgrading_server.rb
@@ -9,6 +9,8 @@ def einhorn_main
   $stderr.puts "Worker has a socket"
   Einhorn::Worker.ack!
   $stderr.puts "Worker sent ack to einhorn"
+  Einhorn::Worker.ping!("id-1")
+  $stderr.puts "Worker has sent a ping to einhorn"
   while true
     s, addrinfo = serv.accept
     $stderr.puts "Worker got a socket!"

--- a/test/integration/upgrading.rb
+++ b/test/integration/upgrading.rb
@@ -78,6 +78,10 @@ class UpgradeTests < EinhornIntegrationTestCase
           state = YAML.load(resp['message'])
           assert_equal(1, state[:state][:children].count)
 
+          child = state[:state][:children].first.last
+          assert_in_delta(child[:pinged_at], Time.now, 60)
+          assert_equal("id-1", child[:pinged_request_id])
+
           process.terminate
         end
       end


### PR DESCRIPTION
Evan I'm going to tag you on this since I was complaining to you about it already.

Adds `Einhorn::worker.ping!("foobar")`, where `foobar` gets put into the state yaml. Can be used to store a request ID + timestamp which can be pulled out by using the state command.

Intentionally not implementing any reaping of workers, because that's scary and we can do that once we're more confident in the pinging itself.