### PR TITLE
Expose the actual bound ports in state to support dynamic port config

### DIFF
--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -340,8 +340,8 @@ module Einhorn
         host = $2
         port = $3
         flags = $4.split(',').select {|flag| flag.length > 0}.map {|flag| flag.downcase}
-        bound_fd, = bind(host, port, flags)
-        fd = (Einhorn::State.sockets[[host, port]] ||= bound_fd)
+        Einhorn::State.sockets[[host, port]] ||= bind(host, port, flags)[0]
+        fd = Einhorn::State.sockets[[host, port]]
         "#{opt}#{fd}"
       else
         arg

--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -340,7 +340,8 @@ module Einhorn
         host = $2
         port = $3
         flags = $4.split(',').select {|flag| flag.length > 0}.map {|flag| flag.downcase}
-        fd, = (Einhorn::State.sockets[[host, port]] ||= bind(host, port, flags))
+        bound_fd, = bind(host, port, flags)
+        fd = (Einhorn::State.sockets[[host, port]] ||= bound_fd)
         "#{opt}#{fd}"
       else
         arg

--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -414,7 +414,6 @@ module Einhorn
       end
       Einhorn::Command::Interface.persistent_init
 
-
       Einhorn::State.orig_cmd = ARGV.dup
       Einhorn::State.cmd = ARGV.dup
       # TODO: don't actually alter ARGV[0]?

--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -45,6 +45,7 @@ module Einhorn
         :orig_cmd => nil,
         :bind => [],
         :bind_fds => [],
+        :bound_ports => [],
         :cmd => nil,
         :script_name => nil,
         :respawn => true,
@@ -162,7 +163,7 @@ module Einhorn
     end
 
     Einhorn::TransientState.socket_handles << sd
-    sd.fileno
+    [sd.fileno, sd.local_address.ip_port]
   end
 
   # Implement these ourselves so it plays nicely with state persistence
@@ -323,8 +324,9 @@ module Einhorn
 
   def self.socketify_env!
     Einhorn::State.bind.each do |host, port, flags|
-      fd = bind(host, port, flags)
+      fd, actual_port = bind(host, port, flags)
       Einhorn::State.bind_fds << fd
+      Einhorn::State.bound_ports << actual_port
     end
   end
 
@@ -338,7 +340,7 @@ module Einhorn
         host = $2
         port = $3
         flags = $4.split(',').select {|flag| flag.length > 0}.map {|flag| flag.downcase}
-        fd = (Einhorn::State.sockets[[host, port]] ||= bind(host, port, flags))
+        fd, = (Einhorn::State.sockets[[host, port]] ||= bind(host, port, flags))
         "#{opt}#{fd}"
       else
         arg
@@ -411,6 +413,7 @@ module Einhorn
         return
       end
       Einhorn::Command::Interface.persistent_init
+
 
       Einhorn::State.orig_cmd = ARGV.dup
       Einhorn::State.cmd = ARGV.dup

--- a/test/unit/einhorn.rb
+++ b/test/unit/einhorn.rb
@@ -10,7 +10,7 @@ class EinhornTest < EinhornTestCase
 
     it "correctly parses srv: arguments" do
       cmd = ['foo', 'srv:1.2.3.4:123,llama,test', 'bar']
-      Einhorn.expects(:bind).once.with('1.2.3.4', '123', ['llama', 'test']).returns(4)
+      Einhorn.expects(:bind).once.with('1.2.3.4', '123', ['llama', 'test']).returns([4, 10087])
 
       Einhorn.socketify!(cmd)
 
@@ -19,7 +19,7 @@ class EinhornTest < EinhornTestCase
 
     it "correctly parses --opt=srv: arguments" do
       cmd = ['foo', '--opt=srv:1.2.3.4:456', 'baz']
-      Einhorn.expects(:bind).once.with('1.2.3.4', '456', []).returns(5)
+      Einhorn.expects(:bind).once.with('1.2.3.4', '456', []).returns([5, 10088])
 
       Einhorn.socketify!(cmd)
 
@@ -28,7 +28,7 @@ class EinhornTest < EinhornTestCase
 
     it "uses the same fd number for the same server spec" do
       cmd = ['foo', '--opt=srv:1.2.3.4:8910', 'srv:1.2.3.4:8910']
-      Einhorn.expects(:bind).once.with('1.2.3.4', '8910', []).returns(10)
+      Einhorn.expects(:bind).once.with('1.2.3.4', '8910', []).returns([10, 10089])
 
       Einhorn.socketify!(cmd)
 


### PR DESCRIPTION
If someone configures einhorn to use :0 as the port the bind call will dynamically assign the ports but the bind array will list port 0.  This PR adds an array to the state that captures the actual bound ports for each bind.

