### PR TITLE
Add support for GC.compact when available

### DIFF
--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -263,6 +263,8 @@ module Einhorn
       GC.start(full_mark: false)
     end
 
+    GC.compact if GC.respond_to?(:compact)
+
     log_info("Finished GC after preloading", :upgrade)
   end
   private_class_method :force_move_to_oldgen

--- a/lib/einhorn/version.rb
+++ b/lib/einhorn/version.rb
@@ -1,3 +1,3 @@
 module Einhorn
-  VERSION = '0.7.12'
+  VERSION = '0.7.13'
 end


### PR DESCRIPTION
r? @asf-stripe 

Ruby 2.7 adds support for GC compaction. This adds a `GC.compact` step at the end of our GCs to force things into oldgen.

I have no idea if it's better to do this before, after, or both, and I'm going with after.