### PR TITLE
Allow smaller spinup intervals

### DIFF
--- a/bin/einhorn
+++ b/bin/einhorn
@@ -267,7 +267,7 @@ if true # $0 == __FILE__
     end
 
     opts.on('-s', '--seconds N', 'Number of seconds to wait until respawning') do |b|
-      Einhorn::State.config[:seconds] = s.to_i
+      Einhorn::State.config[:seconds] = s.to_f
     end
 
     opts.on('-v', '--verbose', 'Make output verbose (can be reconfigured on the fly)') do

--- a/bin/einhorn
+++ b/bin/einhorn
@@ -267,7 +267,10 @@ if true # $0 == __FILE__
     end
 
     opts.on('-s', '--seconds N', 'Number of seconds to wait until respawning') do |b|
-      Einhorn::State.config[:seconds] = s.to_f
+      seconds = Float(s)
+      raise ArgumentError, 'seconds must be > 0' if seconds.zero?
+
+      Einhorn::State.config[:seconds] = seconds
     end
 
     opts.on('-v', '--verbose', 'Make output verbose (can be reconfigured on the fly)') do

--- a/bin/einhorn
+++ b/bin/einhorn
@@ -266,7 +266,7 @@ if true # $0 == __FILE__
       Einhorn::Command.quieter(false)
     end
 
-    opts.on('-s', '--seconds N', 'Number of seconds to wait until respawning') do |b|
+    opts.on('-s', '--seconds N', 'Number of seconds to wait until respawning') do |s|
       seconds = Float(s)
       raise ArgumentError, 'seconds must be > 0' if seconds.zero?
 

--- a/lib/einhorn/command.rb
+++ b/lib/einhorn/command.rb
@@ -595,7 +595,7 @@ module Einhorn
       spinup_interval = Einhorn::State.config[:seconds] * (1.5 ** Einhorn::State.consecutive_deaths_before_ack)
       spinup_interval = [spinup_interval, MAX_SPINUP_INTERVAL].min
       seconds_ago = (Time.now - Einhorn::State.last_spinup).to_f
-      
+
       if seconds_ago > spinup_interval
         if trigger_spinup?(max_unacked)
           msg = "Last spinup was #{seconds_ago}s ago, and spinup_interval is #{spinup_interval}s, so spinning up a new process."


### PR DESCRIPTION
This changes the `--seconds` arg from an `Int` to a `Float` so that we can configure a spinup interval smaller than 1 second.

I also added some unit tests for `Einhorn::Command.replenish_gradually` where this configuration gets used.
