### PR TITLE
Replace deprecated URI.escape method

### DIFF
--- a/lib/einhorn/client.rb
+++ b/lib/einhorn/client.rb
@@ -1,5 +1,4 @@
 require 'set'
-require 'uri'
 require 'yaml'
 
 module Einhorn
@@ -22,12 +21,12 @@ module Einhorn
 
       def self.serialize_message(message)
         serialized = YAML.dump(message)
-        escaped = URI.escape(serialized, "%\n")
+        escaped = serialized.gsub(/%|\n/, '%' => '%25', "\n" => '%0A')
         escaped + "\n"
       end
 
       def self.deserialize_message(line)
-        serialized = URI.unescape(line)
+        serialized = line.gsub(/%(25|0A)/, '%25' => '%', '%0A' => "\n")
         YAML.load(serialized)
       end
     end

--- a/lib/einhorn/version.rb
+++ b/lib/einhorn/version.rb
@@ -1,3 +1,3 @@
 module Einhorn
-  VERSION = '0.8.0'
+  VERSION = '0.8.1'
 end


### PR DESCRIPTION
Replace `URI.escape` and `unescape` which have been deprecated for ~ 10 years https://github.com/ruby/ruby/blob/v2_7_1/lib/uri/common.rb#L84-L86

Ruby 2.7 emits a warning each time these methods are called and causes a lot of chunder in logs.

The original code isn't actually escaping a URI but replacing a couple of specific characters which can be accomplished by using `gsub`. 

This code is explicitly tested in the following existing unit test which passes along with other tests https://git.corp.stripe.com/stripe-private-oss-forks/einhorn/blob/master/test/unit/einhorn/client.rb

