### PR TITLE
rename mourn method in Command module

### DIFF
--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -121,7 +121,7 @@ module Einhorn
         end
       end
       Einhorn::Event::Timer.open(0) do
-        dead.each {|pid| Einhorn::Command.mourn(pid)}
+        dead.each {|pid| Einhorn::Command.cleanup(pid)}
       end
     end
 


### PR DESCRIPTION
Renames `mourn` method to the less metaphorical and more descriptive name `cleanup`. 
This is proposed for both code readability and sensitivity reasons.

Test suite was run locally and everything passed ✅ 