### PR TITLE
Improve example of --reexec-as script

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ pass `-c <name>`.
 You can use the `--reexec-as` option to replace the `einhorn` command with a command or script of your own. This might be useful for those with a Capistrano like deploy process that has changing symlinks. To ensure that you are following the symlinks you could use a bash script like this.
 
     #!/bin/bash
+    
+    set -e # exit when one of the commands returns a non zero exit code
 
     cd <symlinked directory>
     exec /usr/local/bin/einhorn "$@"


### PR DESCRIPTION
Hey 👋  thank you for providing this amazing and very stable library (I was impressed when I learned that it was created such a long time ago).

We started using Einhorn because of Sidekiq Enterprise and rolling restarts - https://github.com/mperham/sidekiq/wiki/Ent-Rolling-Restarts. It includes an [example](https://github.com/mperham/sidekiq/wiki/Ent-Rolling-Restarts#capistrano) which is the copy-pasted version of the example for `--reexec-as` in this repository.

When we were initially integrating Einhorn we observed a weird behaviour when the new code wasn't picked up. We were surprised, because the example for Capistrano is exactly there to remedy this problem. After investigating further we discovered that the path we put in `cd` was incorrect. Unfortunately, the whole script wasn't failing, but just executing Einhorn as normal, so we didn't get any errors.

I believe that this small change that I made will make it easier for others to realise that they made a mistake.