### PR TITLE
add fiddle as an explicit dependency since it will be removed in Ruby 3.5.0

### DIFF
--- a/einhorn.gemspec
+++ b/einhorn.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "minitest", "~> 5"
   gem.add_development_dependency "mocha", "~> 1"
   gem.add_development_dependency "subprocess", "~> 1"
+  gem.add_dependency "fiddle", "~> 1.1"
 end


### PR DESCRIPTION
in ruby 3.4.1 I received a new warning from einhorn announcing the removal of fiddle from the standard library

```
/usr/local/bundle/gems/einhorn-1.0.0/lib/einhorn/prctl_linux.rb:1: warning: /usr/local/lib/ruby/3.4.0/fiddle.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add fiddle to your Gemfile or gemspec to silence this warning.
Also please contact the author of einhorn-1.0.0 to request adding fiddle into its gemspec.
```

Feel free to decline this PR if another approach is more appropriate