### PR TITLE
mark @read_buffer as mutable

### DIFF
--- a/lib/einhorn/event/abstract_text_descriptor.rb
+++ b/lib/einhorn/event/abstract_text_descriptor.rb
@@ -15,7 +15,7 @@ module Einhorn::Event
       @socket = sock
       @client_id = "#{@@instance_counter}:#{sock.fileno}"
 
-      @read_buffer = ""
+      @read_buffer = +""
       @write_buffer = +""
 
       @closed = false


### PR DESCRIPTION
in ruby 3.4, writes to this string emit a "literal string will be frozen in the future ..." warning which is flooding log aggregators.