### PR TITLE
Freeze emptystring in abstract_text_description

### DIFF
--- a/lib/einhorn/event/abstract_text_descriptor.rb
+++ b/lib/einhorn/event/abstract_text_descriptor.rb
@@ -113,7 +113,7 @@ module Einhorn::Event
 
     # Override in subclass. This lets you do streaming reads.
     def parse_record
-      [@read_buffer, ""]
+      [@read_buffer, +""]
     end
 
     def consume_record(record)


### PR DESCRIPTION
Fix another occurrence of Ruby 3.4 chilled string warning in abstract_text_description 

(previous occurence referenced in https://github.com/contribsys/einhorn/pull/115)